### PR TITLE
Custom api base

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ nimble install chatgptclient
 # Requisites
 
 - [Nim](https://nim-lang.org)
+
+# Caveats
+- Note that if you are installing Gtk3+ via Homebrew on macOS running on Apple 
+Silicon, you may need to provide the environment variable 
+`DYLD_LIBRARY_PATH="/opt/homebrew/lib"`.

--- a/chatgptclient.nimble
+++ b/chatgptclient.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "jaredmontoya"
 description   = "Native gui client for OpenAI chatgpt"
 license       = "GPL-3.0-or-later"

--- a/src/chatgptclientpkg/gui.nim
+++ b/src/chatgptclientpkg/gui.nim
@@ -122,9 +122,11 @@ var settingsArea = newLayoutContainer(Layout_Vertical)
 settingsArea.visible = false
 container.add(settingsArea)
 
-var apiKeyInputComponent = newLayoutContainer(Layout_Horizontal)
+var 
+    apiKeyInputComponent = newLayoutContainer(Layout_Horizontal)
+    apiBaseInputComponent = newLayoutContainer(Layout_Horizontal)
 
-var apiKeyInputLabel = newLabel("OpenAI API key:")
+var apiKeyInputLabel = newLabel("API key:")
 apiKeyInputLabel.heightMode = HeightMode_Fill
 apiKeyInputComponent.add(apiKeyInputLabel)
 
@@ -134,11 +136,22 @@ apiKeyInputComponent.add(apiKeyField)
 
 settingsArea.add(apiKeyInputComponent)
 
+var apiBaseInputLabel = newLabel("API url base:")
+apiBaseInputLabel.heightMode = HeightMode_Fill
+apiBaseInputComponent.add(apiBaseInputLabel)
+
+var apiBaseField = newTextBox()
+apiBaseField.text = api.apiBase
+apiBaseInputComponent.add(apiBaseField)
+
+settingsArea.add(apiBaseInputComponent)
+
 var saveButton = newButton("Save")
 settingsArea.add(saveButton)
 
 saveButton.onClick = proc(event: ClickEvent) =
     api.apiKey = apiKeyField.text
+    api.apiBase = apiBaseField.text
 
 buttonChat.onClick = proc(event: ClickEvent) =
     window.title = "Chat"


### PR DESCRIPTION
This PR adds base api field in the settings tab, so one can specify other service provider with compatible API. This PR is very basic, api base setting is not saved upon exit.

As I had issues running compiled binary on Apple Silicon Mac, with libgtk3 dylib installed via homebrew, I've also provided a short hint how to specify additional directory to look for dylibs. That helped me, may it help others as well. 